### PR TITLE
Feature/issue template

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -6,11 +6,11 @@ Provide a detailed description of this issue.
 
 What problem needs to be fixed? What new capability needs to be added?
 
-[Be sure to add a Pipeline, Label, Estimate, Assignees, and Epic](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/issues.html) for further information
+[Be sure to add a Pipeline, Label, Estimate, Assignees, and Epic](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/issues.html)
 
 ## Requirements
 
-What does the new code need to achieve?
+What does the new code need to accomplish?
 
 ## Acceptance Criteria (Definition of Done)
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,25 @@
+## Description
+
+*(Instructions: replace text in this and all sections with your own text)*
+
+Provide a detailed description of this issue.
+
+What problem needs to be fixed? What new capability needs to be added?
+
+[Be sure to add a Pipeline, Label, Estimate, Assignees, and Epic](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/issues.html) for further information
+
+## Requirements
+
+What does the new code need to achieve?
+
+## Acceptance Criteria (Definition of Done)
+
+What does it mean for this to be finished?
+
+## Dependencies
+
+What must be done before this can be done (add issue dependencies as appropriate)?
+
+## Impact
+
+Will addressing this issue require changes to other repositories?

--- a/issue_template.md
+++ b/issue_template.md
@@ -6,11 +6,15 @@ Provide a detailed description of this issue.
 
 What problem needs to be fixed? What new capability needs to be added?
 
+If this is a bug, describe the current behavior.
+
 [Be sure to add a Pipeline, Label, Estimate, Assignees, and Epic](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/issues.html)
 
 ## Requirements
 
-What does the new code need to accomplish?
+If this is a new feature: What does the new code need to accomplish? Does it require new software dependencies (e.g. new jedi-stack components or new python modules?)
+
+If this is a bugfix: What is the expected behavior?
 
 ## Acceptance Criteria (Definition of Done)
 
@@ -18,8 +22,8 @@ What does it mean for this to be finished?
 
 ## Dependencies
 
-What must be done before this can be done (add issue dependencies as appropriate)?
+What must be done before this can be done?
+ - add issue dependencies in ZenHub as appropriate
 
-## Impact
-
-Will addressing this issue require changes to other repositories?
+Does this block progress on other issues?
+ - add this issue as a dependency to other ZenHub issues as appropriate

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -40,9 +40,3 @@ Requires updating AWS test data for the following repositories:
 - [ ] saber
 - [ ] ioda
 - [ ] ...
-
-Note: to automatically run tests for dependent repos, push a commit containing "trigger pipeline", e.g. (*Note* - this requires that you have access to JCSDA's AWS account and even then, it is not available for all repos):
-
-```bash
-git commit --allow-empty -m 'trigger pipeline'
-```

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -41,7 +41,7 @@ Requires updating AWS test data for the following repositories:
 - [ ] ioda
 - [ ] ...
 
-Note: to automatically run tests for dependent repos, push a commit containing "trigger pipeline", e.g. (not available for all repos):
+Note: to automatically run tests for dependent repos, push a commit containing "trigger pipeline", e.g. (*Note* - this requires that you have access to JCSDA's AWS account and even then, it is not available for all repos):
 
 ```bash
 git commit --allow-empty -m 'trigger pipeline'

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -13,6 +13,8 @@ What problem does it fix? What new capability does it add?
 Link the issues to be closed with this PR
 - fixes #<issue_number>
 
+If this does not close an existing issue, then [be sure to add a Pipeline, Label, Estimate, Assignees, and Epic](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/issues.html)
+
 ## Acceptance Criteria (Definition of Done)
 
 What does it mean for this PR to be finished?
@@ -21,21 +23,21 @@ What does it mean for this PR to be finished?
 
 If there are PRs that need to be merged before or along with this one, please add "waiting for another PR" label and list the dependencies in the other repositories (example below). Note that the branches in the other repositories should have matching names for the automated tests to pass.
 Waiting on the following PRs:
-- waiting on JCSDA/eckit/pull/<pr_number>
-- waiting on JCSDA/atlas/pull/<pr_number>
+- [ ] waiting on JCSDA/eckit/pull/<pr_number>
+- [ ] waiting on JCSDA/atlas/pull/<pr_number>
 
 ## Impact
 
 Please list the other repositories (if any) that this PR will require changes in (example below)
 
-- saber
-- ufo
-- ...
+- [ ] saber
+- [ ] ufo
+- [ ] ...
 
 ## Test Data
 
 Please list the test data (if any) that needs to be updated on AWS to the best of your knowledge (example below).
 
-- saber
-- ioda
-- ...
+- [ ] saber
+- [ ] ioda
+- [ ] ...

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,14 +1,21 @@
 ## Description
 
-(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
+*(Instructions: replace text in this and all sections with your own text)*
+
 Provide a detailed description of what this PR does.
-What bug does it fix, or what feature does it add?
-Is a change of answers expected from this PR?
+
+What problem does it fix? What new capability does it add?
+
+[See the JEDI Documentation](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/pullrequest.html) for further information.
 
 ### Issue(s) addressed
 
 Link the issues to be closed with this PR
 - fixes #<issue_number>
+
+## Acceptance Criteria (Definition of Done)
+
+What does it mean for this PR to be finished?
 
 ## Dependencies
 
@@ -18,6 +25,8 @@ Waiting on the following PRs:
 - waiting on JCSDA/atlas/pull/<pr_number>
 
 ## Impact
+
+Is a change of answers expected from this PR for this or other repositories?
 
 If changes in this PR will affect other repositories, please add a "waiting for other repos" label, and list the repositories that will be affected to the best of your knowledge (example below).
 Requires changes in the following repositories:
@@ -32,5 +41,8 @@ Requires updating AWS test data for the following repositories:
 - [ ] ioda
 - [ ] ...
 
-Note: to automatically run saber, ioda and ufo tests with this PR, push a commit containing "trigger pipeline", e.g.:
+Note: to automatically run tests for dependent repos, push a commit containing "trigger pipeline", e.g. (not available for all repos):
+
+```bash
 git commit --allow-empty -m 'trigger pipeline'
+```

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -26,17 +26,16 @@ Waiting on the following PRs:
 
 ## Impact
 
-Is a change of answers expected from this PR for this or other repositories?
+Please list the other repositories (if any) that this PR will require changes in (example below)
 
-If changes in this PR will affect other repositories, please add a "waiting for other repos" label, and list the repositories that will be affected to the best of your knowledge (example below).
-Requires changes in the following repositories:
-- [ ] saber
-- [ ] ioda
-- [ ] ufo
-- [ ] ...
+- saber
+- ufo
+- ...
 
-If changes in this PR require updating test data on AWS please add an "update test data" label and list the test data that needs to be updated to the best of your knowledge (example below).
-Requires updating AWS test data for the following repositories:
-- [ ] saber
-- [ ] ioda
-- [ ] ...
+## Test Data
+
+Please list the test data (if any) that needs to be updated on AWS to the best of your knowledge (example below).
+
+- saber
+- ioda
+- ...


### PR DESCRIPTION
## Description

This modifies the existing JCSDA organization-wide PR template and adds a new organization-wide issue template.  

Purpose: to encourage code developers to create more informative issues and PRs that comply with JCSDA ZenHub reporting practices.

I removed the pipeline comment because triggering the pipelines should probably be done by repo administrators before merging selected PRs - not by everybody.  Furthermore, that functionality is currently only implemented for oops and it is currently not functioning even for oops.

Note - I have not added a milestone because milestones have not been created in this repository.

### Issue(s) addressed

No specific pre-existing issue, but it addresses comments that were raised in our Jan 21, 2021 ZenHub working practices meeting for project leads.

## Dependencies

None

## Impact

This will affect all JCSDA repositories.    The templates will appear every time a contributor creates an issue or issues a PR on any JCSDA repository.  However, if I understand correctly, I believe this can be overridden by templates located in each repository, as for SOCA.
