### PR TITLE
upgrade issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/general-issue-template.md
@@ -1,0 +1,38 @@
+---
+name: General issue template
+about: General JCSDA issue template
+title: "[New issue]"
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+*(Instructions: replace text in this and all sections with your own text)*
+
+Provide a detailed description of this issue.
+
+What problem needs to be fixed? What new capability needs to be added?
+
+If this is a bug, describe the current behavior.
+
+[Be sure to add a Pipeline, Label, Estimate, Assignees, and Epic](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/issues.html)
+
+## Requirements
+
+If this is a new feature: What does the new code need to accomplish? Does it require new software dependencies (e.g. new jedi-stack components or new python modules?)
+
+If this is a bugfix: What is the expected behavior?
+
+## Acceptance Criteria (Definition of Done)
+
+What does it mean for this to be finished?
+
+## Dependencies
+
+What must be done before this can be done?
+ - add issue dependencies in ZenHub as appropriate
+
+Does this block progress on other issues?
+ - add this issue as a dependency to other ZenHub issues as appropriate


### PR DESCRIPTION
The recently added issue template used a deprecated implementation.  This upgrades it to current recommended practice on GitHub