### PR TITLE
Remove "[New Issue]" title in the general issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,7 +1,7 @@
 ---
 name: General issue template
 about: Use this template for general issues
-title: "[New issue]"
+title: ""
 labels: ''
 assignees: ''
 


### PR DESCRIPTION
## Description

This PR removes the "[New Issue]" title from the general issue template. The "[New Issue]" title is confusing as the issue moves through our ZenHub pipelines because one of the pipelines is also named "New Issues".

I'm absolutely open to changing the general issue template title to something besides "[New Issue]" if reviewers feel that's a better solution.

## Issue(s) addressed

None

## Dependencies

List the other PRs that this PR is dependent on:
None

## Impact

Expected impact on downstream repositories:
None

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
