### PR TITLE
fix: correct YAML step syntax in helpdesk-triage-labels workflow

### DIFF
--- a/.github/workflows/helpdesk-triage-labels.yml
+++ b/.github/workflows/helpdesk-triage-labels.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Parse issue form fields and apply labels
-      - uses: actions/github-script@v7
+        uses: actions/github-script@v7
         with:
           script: |
             const owner = context.repo.owner;


### PR DESCRIPTION
## Summary

- The `uses:` key in `helpdesk-triage-labels.yml` was incorrectly written as `- uses:` (a new list item), making it a separate step instead of a property of the named step.
- GitHub Actions parsed this as two steps: one with only a `name` (invalid — no `run` or `uses`) and one orphaned `github-script` step, causing the workflow to fail on every run.
- Fixed by removing the erroneous `- ` prefix so `uses:` is correctly indented as a property of the same step.

Addresses https://github.com/JCSDA-internal/github-admin/issues/137
