### PR TITLE
helpdesk template: use partner and project dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/Helpdesk.yml
+++ b/.github/ISSUE_TEMPLATE/Helpdesk.yml
@@ -24,19 +24,18 @@ body:
       label: Requesting Organization
       description: Select the organization requesting assistance or project if applicable.
       options:
-        - Other
         - CADRE
-        - FALCON
-        - RRFS
+        - NRL-FALCON
+        - NRL-Space Weather
+        - OAR-RRFS
+        - OAR-EPIC
         - MMM
         - NASA
-        - Navy
         - NESDIS
         - NWS
-        - OAR-EPIC
         - UKMO
-        - University
         - USAF
+        - Other
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/Helpdesk.yml
+++ b/.github/ISSUE_TEMPLATE/Helpdesk.yml
@@ -24,6 +24,7 @@ body:
       label: Requesting Organization
       description: Select the organization requesting assistance or project if applicable.
       options:
+        - Other
         - CADRE
         - FALCON
         - RRFS
@@ -36,7 +37,6 @@ body:
         - UKMO
         - University
         - USAF
-        - Other
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/Helpdesk.yml
+++ b/.github/ISSUE_TEMPLATE/Helpdesk.yml
@@ -18,12 +18,25 @@ body:
     validations:
       required: true
 
-  - type: textarea
+  - type: dropdown
     id: requesting_org
     attributes:
       label: Requesting Organization
-      description: Specify the organization and, if applicable, the specific division, branch, or office requesting assistance.
-      placeholder: "e.g., University, NOAA/NWS/EMC, NRL Monterey, NASA/GMAO"
+      description: Select the organization requesting assistance or project if applicable.
+      options:
+        - CADRE
+        - FALCON
+        - RRFS
+        - MMM
+        - NASA
+        - Navy
+        - NESDIS
+        - NWS
+        - OAR-EPIC
+        - UKMO
+        - University
+        - USAF
+        - Other
     validations:
       required: true
 


### PR DESCRIPTION
## Description

Update "Requester Organization" section in the Helpdesk template to use a drop down menu of partners and projects:
        - CADRE (christian)
        - NRL-FALCON (Francios V)
        - NRL-Space Weather (FV)
        - OAR-RRFS (Nate)
        - OAR-EPIC (Phil)
        - MMM (Ben R)
        - NASA (Yannick)
        - NESDIS (Ben R)
        - NWS (Yannick)
        - UKMO (Yannick)
        - USAF (Ben R)
        - Other (Phil)
These will be used to map JCSDA assignees in https://github.com/JCSDA-internal/.github/pull/20

## Issue(s) addressed

Resolves #22 

## Dependencies

None

## Impact

Expected impact on downstream repositories:

## Manual Testing Instructions (optional)

If you would like your reviewers to manually build and test the change, please include
instructions on how the change should be built and tested. Also include a short
justification on why manual testing is necessary for this change.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
